### PR TITLE
feat: Allow user to skip symlink step

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 greenbay_sha: ""
 greenbay_package_url: http://s3.amazonaws.com/boxes.10gen.com/build/greenbay/greenbay-dist-{{ platform }}-{{ greenbay_sha }}.tar.gz
+greenbay_symlink: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,4 +18,6 @@
     state: link
     path: /usr/bin/greenbay
     src: /usr/local/bin/greenbay
-  when: usr_bin.stat.exists
+  when:
+    - usr_bin.stat.exists
+    - greenbay_symlink is true


### PR DESCRIPTION
This doesn't work on macos-1100 because /usr/bin is a read-only
filesystem
